### PR TITLE
🔖 (DANE) Bump version to 0.16

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -1492,7 +1492,7 @@
     "name": "Digital Assistant, not EDITH",
     "shortName": "DANE",
     "icon": "app.png",
-    "version": "0.15",
+    "version": "0.16",
     "description": "A Watchface inspired by Tony Stark's EDITH and based on https://arwes.dev/",
     "tags": "clock",
     "type": "clock",

--- a/apps/dane/ChangeLog
+++ b/apps/dane/ChangeLog
@@ -11,3 +11,4 @@
 0.13: Improve icon
 0.14: Switch Icon back to 8bit web palette to fix it
 0.15: Hotfix: Remove var declaration from app image
+0.16: Revert: Change Counter back to button control


### PR DESCRIPTION
Bump version of DANE Watchface to 0.16 in preparation of release/dane/0.16

Signed-off-by: OmegaRogue <omegarogue@omegavoid.codes>